### PR TITLE
Add missing parameters for agent associate_static_ip

### DIFF
--- a/appscale/agents/azure_agent.py
+++ b/appscale/agents/azure_agent.py
@@ -985,10 +985,12 @@ class AzureAgent(BaseAgent):
           "while trying to create Scale Set. Please check your cloud "
           "configuration. Reason: {}".format(e.message))
 
-  def associate_static_ip(self, instance_id, static_ip):
+  def associate_static_ip(self, parameters, instance_id, static_ip):
     """ Associates the given static IP address with the given instance ID.
 
     Args:
+      parameters: A dict, containing all the parameters necessary to
+        authenticate this user with Azure.
       instance_id: A str that names the instance that the static IP should be
         bound to.
       static_ip: A str naming the static IP to bind to the given instance.

--- a/appscale/agents/base_agent.py
+++ b/appscale/agents/base_agent.py
@@ -106,10 +106,12 @@ class BaseAgent(object):
     raise NotImplementedError
 
 
-  def associate_static_ip(self, instance_id, static_ip):
+  def associate_static_ip(self, parameters, instance_id, static_ip):
     """Associates the given static IP address with the given instance ID.
 
     Args:
+      parameters: A dict containing values necessary to authenticate with the
+        underlying cloud.
       instance_id: A str that names the instance that the static IP should be
         bound to.
       static_ip: A str naming the static IP to bind to the given instance.


### PR DESCRIPTION
The azure agent and base methods were missing `parameters`.

I think this is just clean up and does not impact functionality.