### PR TITLE
Add missing handle_failure method for gce agent

### DIFF
--- a/appscale/agents/gce_agent.py
+++ b/appscale/agents/gce_agent.py
@@ -1250,6 +1250,17 @@ class GCEAgent(BaseAgent):
             response['error']['errors']])
           raise AgentRuntimeException(str(message))
 
+  def handle_failure(self, msg):
+    """ Log the specified error message and raise an AgentRuntimeException
+
+    Args:
+      msg: An error message to be logged and included in the raised exception.
+    Raises:
+      AgentRuntimeException Contains the input error message.
+    """
+    logger.info(msg)
+    raise AgentRuntimeException(msg)
+
   def __test_logging(self):
     logger.info("gceagent info log")
     logger.debug("gceagent debug log")


### PR DESCRIPTION
The gce agent uses a `handle_failure` method which is currently only defined for the ec2 agent.

https://github.com/AppScale/appscale-agents/blob/aa623220543368d09c79968010757a5d5c0e6df3/appscale/agents/gce_agent.py#L806-L808