### PR TITLE
Adjust GCE Agent to be able to use images outside of the caller's project.

### DIFF
--- a/appscale/agents/gce_agent.py
+++ b/appscale/agents/gce_agent.py
@@ -737,8 +737,28 @@ class GCEAgent(BaseAgent):
       self.describe_instances(parameters)
 
     # Construct URLs
-    image_url = '{0}{1}/global/images/{2}'.format(self.GCE_URL, project_id,
-      image_id)
+
+    # This overloads the image_id string so we don't have to introduce
+    # yet another environment variable. This allows the user to specify
+    # A project name along with the image to use an image defined by someone
+    # else
+    #
+    # Examples:
+    # ubuntu-1604-lts -> uses image from project_id passed to this method
+    # ubuntu-os-cloud/ubuntu-1604-lts -> uses latest family image from
+    #                                    Canonical (ubuntu-os-cloud)
+    # ubuntu-os-cloud/ubuntu-1604-xenial-20190628 -> uses specific ubuntu image
+    #                                    from Canonical
+    #
+    if '/' in image_id:
+      image_project_id, real_image_id = image_id.split('/', 1)
+    else:
+      image_project_id = project_id
+      real_image_id = image_id
+
+    image_url = '{0}{1}/global/images/{2}'.format(self.GCE_URL,
+                                                  image_project_id,
+                                                  real_image_id)
     project_url = '{0}{1}'.format(self.GCE_URL, project_id)
     machine_type_url = '{0}/zones/{1}/machineTypes/{2}'.format(project_url,
       zone, instance_type)

--- a/appscale/agents/gce_agent.py
+++ b/appscale/agents/gce_agent.py
@@ -745,10 +745,10 @@ class GCEAgent(BaseAgent):
     #
     # Examples:
     # ubuntu-1604-lts -> uses image from project_id passed to this method
-    # ubuntu-os-cloud/ubuntu-1604-lts -> uses latest family image from
-    #                                    Canonical (ubuntu-os-cloud)
+    # ubuntu-os-cloud/family/ubuntu-1604-lts -> uses latest family image from
+    #                                           Canonical (ubuntu-os-cloud)
     # ubuntu-os-cloud/ubuntu-1604-xenial-20190628 -> uses specific ubuntu image
-    #                                    from Canonical
+    #                                                from Canonical
     #
     if '/' in image_id:
       image_project_id, real_image_id = image_id.split('/', 1)

--- a/appscale/agents/gce_agent.py
+++ b/appscale/agents/gce_agent.py
@@ -749,8 +749,9 @@ class GCEAgent(BaseAgent):
     #                                           Canonical (ubuntu-os-cloud)
     # ubuntu-os-cloud/ubuntu-1604-xenial-20190628 -> uses specific ubuntu image
     #                                                from Canonical
+    # family/ubuntu-1604-lts -> use image family from project_id passed to this method.
     #
-    if '/' in image_id:
+    if '/' in image_id and not image_id.startsiwth('family'):
       image_project_id, real_image_id = image_id.split('/', 1)
     else:
       image_project_id = project_id

--- a/appscale/agents/gce_agent.py
+++ b/appscale/agents/gce_agent.py
@@ -686,8 +686,8 @@ class GCEAgent(BaseAgent):
     disk_name = self.generate_disk_name(parameters)
     project_url = '{0}{1}'.format(self.GCE_URL,
       parameters[self.PARAM_PROJECT])
-    source_image_url = '{0}{1}/global/images/{2}'.format(self.GCE_URL,
-      parameters[self.PARAM_PROJECT], parameters[self.PARAM_IMAGE_ID])
+    source_image_url = self.get_image_url(parameters[self.PARAM_PROJECT],
+                                          parameters[self.PARAM_IMAGE_ID])
     request = gce_service.disks().insert(
       project=parameters[self.PARAM_PROJECT],
       zone=parameters[self.PARAM_ZONE],
@@ -704,6 +704,42 @@ class GCEAgent(BaseAgent):
     disk_url = "{0}/zones/{1}/disks/{2}".format(
       project_url, parameters[self.PARAM_ZONE], disk_name)
     return disk_url
+
+  def get_image_url(self, project_id, image_id):
+    """
+    Construct a google URL for the image_id
+
+    The image_id can have various forms which determine what project_id is used
+
+    project_id / image_id used as is:
+     - If the image_id is a string with no path separators
+     - If the image_id startswith 'family/'
+
+    project_id / image_id is manipulated:
+     - If the image_id is a string with a path separator
+     - Image_id does not start with 'family/'
+     - Project_id is constructed from the first part of the 'path', the rest
+       is the image id.
+
+    Examples:
+    ubuntu-1604-lts -> uses image from project_id passed to this method
+    family/ubuntu-1604-lts -> use image family from project_id passed to this method.
+
+    ubuntu-os-cloud/family/ubuntu-1604-lts -> uses latest family image from
+                                              Canonical project (ubuntu-os-cloud)
+    ubuntu-os-cloud/ubuntu-1604-xenial-20190628 -> uses specific ubuntu image
+                                                   from Canonical project
+    """
+    if '/' in image_id and not image_id.startswith('family/'):
+      image_project_id, real_image_id = image_id.split('/', 1)
+    else:
+      image_project_id = project_id
+      real_image_id = image_id
+
+    image_url = '{0}{1}/global/images/{2}'.format(self.GCE_URL,
+                                                  image_project_id,
+                                                  real_image_id)
+    return image_url
 
   def run_instances(self, count, parameters, security_configured, public_ip_needed):
     """ Starts 'count' instances in Google Compute Engine, and returns once they
@@ -737,29 +773,7 @@ class GCEAgent(BaseAgent):
       self.describe_instances(parameters)
 
     # Construct URLs
-
-    # This overloads the image_id string so we don't have to introduce
-    # yet another environment variable. This allows the user to specify
-    # A project name along with the image to use an image defined by someone
-    # else
-    #
-    # Examples:
-    # ubuntu-1604-lts -> uses image from project_id passed to this method
-    # ubuntu-os-cloud/family/ubuntu-1604-lts -> uses latest family image from
-    #                                           Canonical (ubuntu-os-cloud)
-    # ubuntu-os-cloud/ubuntu-1604-xenial-20190628 -> uses specific ubuntu image
-    #                                                from Canonical
-    # family/ubuntu-1604-lts -> use image family from project_id passed to this method.
-    #
-    if '/' in image_id and not image_id.startswith('family'):
-      image_project_id, real_image_id = image_id.split('/', 1)
-    else:
-      image_project_id = project_id
-      real_image_id = image_id
-
-    image_url = '{0}{1}/global/images/{2}'.format(self.GCE_URL,
-                                                  image_project_id,
-                                                  real_image_id)
+    image_url = self.get_image_url(project_id, image_id)
     project_url = '{0}{1}'.format(self.GCE_URL, project_id)
     machine_type_url = '{0}/zones/{1}/machineTypes/{2}'.format(project_url,
       zone, instance_type)

--- a/appscale/agents/gce_agent.py
+++ b/appscale/agents/gce_agent.py
@@ -751,7 +751,7 @@ class GCEAgent(BaseAgent):
     #                                                from Canonical
     # family/ubuntu-1604-lts -> use image family from project_id passed to this method.
     #
-    if '/' in image_id and not image_id.startsiwth('family'):
+    if '/' in image_id and not image_id.startswith('family'):
       image_project_id, real_image_id = image_id.split('/', 1)
     else:
       image_project_id = project_id


### PR DESCRIPTION
**Overview**:
This PR is to get our agent to a point where we can build off of the default ubuntu images provided by Canonical. With the current agent, all resources have to originate from the same project_id. This makes it necessary to copy over the ubuntu image over to our project. Ultimately this should get us out of the problem of image builds taking longer and longer because of distro updates.

We also now have the ability to reference a family of images, which will pick up the latest image in the series. Hopefully this gets us to the point where we don't need to change the build environment at all when Canonical releases new ubuntu images in a family.

**Example image names**:
```
    ubuntu-1604-lts -> uses image from project_id passed to this method
    family/ubuntu-1604-lts -> use image family from project_id passed to this method.
    ubuntu-os-cloud/family/ubuntu-1604-lts -> uses latest family image from
                                              Canonical project (ubuntu-os-cloud)
    ubuntu-os-cloud/ubuntu-1604-xenial-20190628 -> uses specific ubuntu image
                                                   from Canonical project
```

The testing repo will be changed to use: ubuntu-os-cloud/family/ubuntu-1604-lts
as the default image_id.

**Demo**: 
Master appscale-testing branch (to verify no regression): http://ocd.appscale.net:8080/view/all/job/Create-GCE-Image/732/ . Build might fail, but the image launched correctly.

Build with topic branches, to verify functionality: http://ocd.appscale.net:8080/view/all/job/Create-GCE-Image/731/
