### PR TITLE
EC2 agent support for attaching volumes as nvme devices

### DIFF
--- a/appscale/agents/ec2_agent.py
+++ b/appscale/agents/ec2_agent.py
@@ -886,6 +886,8 @@ class EC2Agent(BaseAgent):
       mount_point = '/dev/xvdc'
     elif glob.glob("/dev/vd*"):
       mount_point = '/dev/vdc'
+    elif glob.glob('/dev/nvme*'):
+      mount_point = '/dev/nvme1n1'
     else:
       mount_point = '/dev/sdc'
 


### PR DESCRIPTION
EC2 agent update for attaching volumes as NVMe devices as per:

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/nvme-ebs-volumes.html