### PR TITLE
Generate shorter hostnames on GCE and Azure

### DIFF
--- a/appscale/agents/azure_agent.py
+++ b/appscale/agents/azure_agent.py
@@ -69,7 +69,6 @@ from azure.mgmt.storage.models import Sku as StorageSku
 from msrestazure.azure_active_directory import ServicePrincipalCredentials
 from msrest.exceptions import ClientException
 from msrestazure.azure_exceptions import CloudError
-from haikunator import Haikunator
 
 # AppScale-specific imports
 from .config import AppScaleState
@@ -557,7 +556,9 @@ class AzureAgent(BaseAgent):
       availability_set: An Availability Set instance for the load balancer VMs.
     """
     resource_group = parameters[self.PARAM_RESOURCE_GROUP]
-    vm_network_name = Haikunator().haikunate()
+    # Azure machines get a smaller hostname because they get assigned an
+    # unreasonably long DNS suffix (51 characters).
+    vm_network_name = self._gen_machine_id(6)
     self.create_network_interface(network_client, vm_network_name,
                                   vm_network_name, subnet, parameters)
     network_interface = network_client.network_interfaces.get(
@@ -793,7 +794,9 @@ class AzureAgent(BaseAgent):
         AgentConfigurationException: If the operation to create a virtual
         machine scale set did not succeed.
     """
-    random_resource_name = Haikunator().haikunate()
+    # Azure machines get a smaller hostname because they get assigned an
+    # unreasonably long DNS suffix (51 characters).
+    random_resource_name = self._gen_machine_id(6)
 
     num_instances_to_add = count
 

--- a/appscale/agents/base_agent.py
+++ b/appscale/agents/base_agent.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import logging
+import random
+import string
 
 logger = logging.getLogger(__name__)
 
@@ -260,6 +262,18 @@ class BaseAgent(object):
       if item not in list2:
         diffed_list.append(item)
     return diffed_list
+
+  @staticmethod
+  def _gen_machine_id(length=8):
+    """
+    Generates an ID that's meant to be unique for a machine within a
+    deployment.
+
+    Returns:
+      A string specifying a machine ID.
+    """
+    return ''.join(random.choice(string.lowercase + string.digits)
+                   for _ in range(length))
 
   def __test_logging(self):
     """ Output a couple of messages at different logging levels"""

--- a/appscale/agents/gce_agent.py
+++ b/appscale/agents/gce_agent.py
@@ -785,7 +785,7 @@ class GCEAgent(BaseAgent):
       instances = {
         # Truncate the name down to the first 62 characters, since GCE doesn't
         # let us use arbitrarily long instance names.
-        'name': '{group}-{uuid}'.format(group=group, uuid=uuid.uuid4())[:62],
+        'name': '-'.join([group, self._gen_machine_id()])[:62],
         'machineType': machine_type_url,
         'disks':[{
           'source': disk_url,

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ setup(
     'argparse',
     'boto',
     'google-api-python-client==1.5.4',
-    'haikunator',
     'httplib2',
     'msrestazure==0.4.34',
     'oauth2client==4.0.0',


### PR DESCRIPTION
Machines end up with very long FQDNs on these platforms, which ejabberd uses to generate a certificate upon installation. This change allows ejabberd to be installed successfully.

Resolves https://github.com/AppScale/appscale-testing/issues/408.

Unfortunately, the removal of Haikunator makes the world a colder and darker place.