### PR TITLE
Add explicit keyring dependencies to constrain version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
     'boto',
     'google-api-python-client==1.5.4',
     'httplib2',
+    'keyring>=12.0.2,<19.0.0',
+    'keyrings.alt>=3.1,<3.2',
     'msrestazure==0.4.34',
     'oauth2client==4.0.0',
     'PyYAML',


### PR DESCRIPTION
Keyring is a transitive dependency via azure. This pull request constrains the installed version so it is the last python 2 compatible one and ensures that a suitable `keyrings.alt` dependency is installed. 

Without the `keyrings.alt` dependency the OS package `python-keyrings.alt` is used on bionic which is incompatible with keyring 18. The `python-keyrings.alt` package is a recommended dependency via `python-pip` so a workaround is to remove it (`dpkg -r python-keyrings.alt`)

Without the fix and with additional logging the `appscale` command shows the error:

```
ERROR:keyring.backend:Error initializing plugin EntryPoint('Windows (alt)', u'keyrings.alt.Windows', None, Distribution('keyrings.alt', '3.0')).
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/keyring/backend.py", line 194, in _load_plugins
    init_func = ep.load()
  File "/usr/local/lib/python2.7/dist-packages/entrypoints.py", line 82, in load
    mod = import_module(self.module_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/usr/lib/python2.7/dist-packages/keyrings/alt/Windows.py", line 9, in <module>
    from . import file_base
  File "/usr/lib/python2.7/dist-packages/keyrings/alt/file_base.py", line 13, in <module>
    from keyring.util.escape import escape as escape_for_ini
ImportError: No module named escape
ERROR:keyring.backend:Error initializing plugin EntryPoint('file', u'keyrings.alt.file', None, Distribution('keyrings.alt', '3.0')).
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/keyring/backend.py", line 194, in _load_plugins
    init_func = ep.load()
  File "/usr/local/lib/python2.7/dist-packages/entrypoints.py", line 82, in load
    mod = import_module(self.module_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/usr/lib/python2.7/dist-packages/keyrings/alt/file.py", line 11, in <module>
    from keyring.util.escape import escape as escape_for_ini
ImportError: No module named escape
ERROR:keyring.backend:Error initializing plugin EntryPoint('pyfs', u'keyrings.alt.pyfs', None, Distribution('keyrings.alt', '3.0')).
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/keyring/backend.py", line 194, in _load_plugins
    init_func = ep.load()
  File "/usr/local/lib/python2.7/dist-packages/entrypoints.py", line 82, in load
    mod = import_module(self.module_name)
  File "/usr/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/usr/lib/python2.7/dist-packages/keyrings/alt/pyfs.py", line 8, in <module>
    from keyring.util.escape import escape as escape_for_ini
ImportError: No module named escape
...
```

Without the additional logging:

```
# appscale status
No handlers could be found for logger "keyring.backend"
...
```

This does not appear to cause any functionality issues for the `appscale` command but it is possible that there are other issues with the azure agent due to the incompatible dependency.